### PR TITLE
relove the problem of crash when js call java with chinese character

### DIFF
--- a/library/src/main/assets/WebViewJavascriptBridge.js
+++ b/library/src/main/assets/WebViewJavascriptBridge.js
@@ -92,7 +92,7 @@
             return messageQueueString;
             //android can't read directly the return data, so we can reload iframe src to communicate with java
         } else if (isAndroid()) {
-            messagingIframe.src = CUSTOM_PROTOCOL_SCHEME + '://return/_fetchQueue/' + escape(messageQueueString);
+            messagingIframe.src = CUSTOM_PROTOCOL_SCHEME + '://return/_fetchQueue/' + encodeURIComponent(messageQueueString);
         }
     }
 


### PR DESCRIPTION
### BUG descriptioin

when js call java registered BridgeHandler with chinese character parameter, Android app will crash caused by the **URLDecoder.decode(url)**  in  **shouldOverrideUrlLoading()**  method.

### SAMPLE

#### java end
``` java
 mJsBridge.registerHandler("sendMsg", new BridgeHandler() {
            @Override
            public void handler(String data, final CallBackFunction function) {
                Log.i( "test",  "js call java" + data);
            }
        });
```

#### js end
```
var paramObj = {};
paramObj.phone = "13888888888";
paramObj.msgcontent = '短信测试内容';
var paramStr = JSON.stringify(paramObj);
if(window.WebViewJavascriptBridge){
    WebViewJavascriptBridge.callHandler("sendMsg", paramStr, null);
}
```