### PR TITLE
JS调用Android端没有的方法会抛空指针异常

### DIFF
--- a/library/src/main/java/com/github/lzyzsd/jsbridge/BridgeWebView.java
+++ b/library/src/main/java/com/github/lzyzsd/jsbridge/BridgeWebView.java
@@ -225,7 +225,9 @@ public class BridgeWebView extends WebView implements WebViewJavascriptBridge {
 							} else {
 								handler = defaultHandler;
 							}
-							handler.handler(m.getData(), responseFunction);
+							if(handler!=null){
+								handler.handler(m.getData(), responseFunction);
+							}
 						}
 					}
 				}


### PR DESCRIPTION
JS调用Android端没有的方法会抛空指针异常，增加非空判断