### PR TITLE
fixbug:lost message

### DIFF
--- a/library/src/main/assets/WebViewJavascriptBridge.js
+++ b/library/src/main/assets/WebViewJavascriptBridge.js
@@ -7,6 +7,7 @@
     }
 
     var messagingIframe;
+    var bizMessagingIframe;
     var sendMessageQueue = [];
     var receiveMessageQueue = [];
     var messageHandlers = {};
@@ -17,13 +18,18 @@
     var responseCallbacks = {};
     var uniqueId = 1;
 
-    // 创建队列iframe
+    // 创建消息index队列iframe
     function _createQueueReadyIframe(doc) {
         messagingIframe = doc.createElement('iframe');
         messagingIframe.style.display = 'none';
         doc.documentElement.appendChild(messagingIframe);
     }
-
+    //创建消息体队列iframe
+    function _createQueueReadyIframe4biz(doc) {
+        bizMessagingIframe = doc.createElement('iframe');
+        bizMessagingIframe.style.display = 'none';
+        doc.documentElement.appendChild(bizMessagingIframe);
+    }
     //set default messageHandler  初始化默认的消息线程
     function init(messageHandler) {
         if (WebViewJavascriptBridge._messageHandler) {
@@ -73,7 +79,7 @@
         var messageQueueString = JSON.stringify(sendMessageQueue);
         sendMessageQueue = [];
         //android can't read directly the return data, so we can reload iframe src to communicate with java
-        messagingIframe.src = CUSTOM_PROTOCOL_SCHEME + '://return/_fetchQueue/' + encodeURIComponent(messageQueueString);
+        bizMessagingIframe.src = CUSTOM_PROTOCOL_SCHEME + '://return/_fetchQueue/' + encodeURIComponent(messageQueueString);
     }
 
     //提供给native使用,
@@ -138,6 +144,7 @@
 
     var doc = document;
     _createQueueReadyIframe(doc);
+    _createQueueReadyIframe4biz(doc);
     var readyEvent = doc.createEvent('Events');
     readyEvent.initEvent('WebViewJavascriptBridgeReady');
     readyEvent.bridge = WebViewJavascriptBridge;


### PR DESCRIPTION
在使用时竟然丢消息，通过创建两个iframe，原有iframe仅仅只做消息通知，新建另外的iframe做消息体发送。所以目前流程为:

iframe1->通知native fetch消息 ->前端环境收到fetch请求->iframe2发送消息