### PR TITLE
add escape rule for json string

### DIFF
--- a/library/src/main/java/com/github/lzyzsd/jsbridge/BridgeWebView.java
+++ b/library/src/main/java/com/github/lzyzsd/jsbridge/BridgeWebView.java
@@ -129,6 +129,7 @@ public class BridgeWebView extends WebView implements WebViewJavascriptBridge {
         //escape special characters for json string
         messageJson = messageJson.replaceAll("(\\\\)([^utrn])", "\\\\\\\\$1$2");
         messageJson = messageJson.replaceAll("(?<=[^\\\\])(\")", "\\\\\"");
+		messageJson = messageJson.replaceAll("(?<=[^\\\\])(\')", "\\\\\'");
         String javascriptCommand = String.format(BridgeUtil.JS_HANDLE_MESSAGE_FROM_JAVA, messageJson);
         if (Thread.currentThread() == Looper.getMainLooper().getThread()) {
             this.loadUrl(javascriptCommand);


### PR DESCRIPTION
replace ‘ in json string with /‘
去掉json字符串中的单引号