### PR TITLE
重构了库内部的webview和webviewclient的代码

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -29,7 +29,7 @@ dependencies {
 
 def siteUrl = 'https://github.com/lzyzsd/JsBridge'
 def gitUrl = 'https://github.com/lzyzsd/JsBridge.git'
-apply plugin: 'com.github.dcendents.android-maven'
+//apply plugin: 'com.github.dcendents.android-maven'
 group = "com.github.lzyzsd.jsbridge"
 task sourcesJar(type: Jar) {
     from android.sourceSets.main.java.srcDirs

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -29,7 +29,7 @@ dependencies {
 
 def siteUrl = 'https://github.com/lzyzsd/JsBridge'
 def gitUrl = 'https://github.com/lzyzsd/JsBridge.git'
-//apply plugin: 'com.github.dcendents.android-maven'
+apply plugin: 'com.github.dcendents.android-maven'
 group = "com.github.lzyzsd.jsbridge"
 task sourcesJar(type: Jar) {
     from android.sourceSets.main.java.srcDirs

--- a/library/src/main/java/com/github/lzyzsd/jsbridge/BridgeWebChromeClient.java
+++ b/library/src/main/java/com/github/lzyzsd/jsbridge/BridgeWebChromeClient.java
@@ -1,0 +1,243 @@
+package com.github.lzyzsd.jsbridge;
+
+import android.annotation.TargetApi;
+import android.graphics.Bitmap;
+import android.net.Uri;
+import android.os.Build;
+import android.view.View;
+import android.webkit.ConsoleMessage;
+import android.webkit.GeolocationPermissions;
+import android.webkit.JsPromptResult;
+import android.webkit.JsResult;
+import android.webkit.PermissionRequest;
+import android.webkit.ValueCallback;
+import android.webkit.WebChromeClient;
+import android.webkit.WebStorage;
+import android.webkit.WebView;
+
+class BridgeWebChromeClient extends WebChromeClient {
+    private WebChromeClient webChromeClientProxy;
+    public BridgeWebChromeClient(WebChromeClient webChromeClient) {
+        this.webChromeClientProxy = webChromeClient;
+    }
+
+    @Override
+    public void onProgressChanged(WebView view, int newProgress) {
+        if (webChromeClientProxy != null) {
+            webChromeClientProxy.onProgressChanged(view, newProgress);
+        }
+        super.onProgressChanged(view, newProgress);
+    }
+
+    @Override
+    public void onReceivedTitle(WebView view, String title) {
+        if (webChromeClientProxy != null) {
+            webChromeClientProxy.onReceivedTitle(view, title);
+        }
+        super.onReceivedTitle(view, title);
+    }
+
+    @Override
+    public void onReceivedIcon(WebView view, Bitmap icon) {
+        if (webChromeClientProxy != null) {
+            webChromeClientProxy.onReceivedIcon(view, icon);
+        }
+        super.onReceivedIcon(view, icon);
+    }
+
+    @Override
+    public void onReceivedTouchIconUrl(WebView view, String url, boolean precomposed) {
+        if (webChromeClientProxy != null) {
+            webChromeClientProxy.onReceivedTouchIconUrl(view, url, precomposed);
+        }
+        super.onReceivedTouchIconUrl(view, url, precomposed);
+    }
+
+    @Override
+    public void onShowCustomView(View view, CustomViewCallback callback) {
+        if (webChromeClientProxy != null) {
+            webChromeClientProxy.onShowCustomView(view, callback);
+        }
+        super.onShowCustomView(view, callback);
+    }
+
+    @TargetApi(Build.VERSION_CODES.ICE_CREAM_SANDWICH)
+    @Override
+    public void onShowCustomView(View view, int requestedOrientation, CustomViewCallback callback) {
+        if (webChromeClientProxy != null) {
+            webChromeClientProxy.onShowCustomView(view, requestedOrientation, callback);
+        }
+        super.onShowCustomView(view, requestedOrientation, callback);
+    }
+
+    @Override
+    public void onHideCustomView() {
+        if (webChromeClientProxy != null) {
+            webChromeClientProxy.onHideCustomView();
+        }
+        super.onHideCustomView();
+    }
+
+    @Override
+    public boolean onCreateWindow(WebView view, boolean isDialog, boolean isUserGesture, android.os.Message resultMsg) {
+        if (webChromeClientProxy != null) {
+            webChromeClientProxy.onCreateWindow(view, isDialog, isUserGesture, resultMsg);
+        }
+        return super.onCreateWindow(view, isDialog, isUserGesture, resultMsg);
+    }
+
+    @Override
+    public void onRequestFocus(WebView view) {
+        if (webChromeClientProxy != null) {
+            webChromeClientProxy.onRequestFocus(view);
+        }
+        super.onRequestFocus(view);
+    }
+
+    @Override
+    public void onCloseWindow(WebView window) {
+        if (webChromeClientProxy != null) {
+            webChromeClientProxy.onCloseWindow(window);
+        }
+        super.onCloseWindow(window);
+    }
+
+    @Override
+    public boolean onJsAlert(WebView view, String url, String message, JsResult result) {
+        if (webChromeClientProxy != null) {
+            webChromeClientProxy.onJsAlert(view, url, message, result);
+        }
+        return super.onJsAlert(view, url, message, result);
+    }
+
+    @Override
+    public boolean onJsConfirm(WebView view, String url, String message, JsResult result) {
+        if (webChromeClientProxy != null) {
+            webChromeClientProxy.onJsConfirm(view, url, message, result);
+        }
+        return super.onJsConfirm(view, url, message, result);
+    }
+
+    @Override
+    public boolean onJsPrompt(WebView view, String url, String message, String defaultValue, JsPromptResult result) {
+        if (webChromeClientProxy != null) {
+            webChromeClientProxy.onJsPrompt(view, url, message, defaultValue, result);
+        }
+        return super.onJsPrompt(view, url, message, defaultValue, result);
+    }
+
+    @Override
+    public boolean onJsBeforeUnload(WebView view, String url, String message, JsResult result) {
+        if (webChromeClientProxy != null) {
+            webChromeClientProxy.onJsBeforeUnload(view, url, message, result);
+        }
+        return super.onJsBeforeUnload(view, url, message, result);
+    }
+
+    @Override
+    public void onExceededDatabaseQuota(String url, String databaseIdentifier, long quota, long estimatedDatabaseSize, long totalQuota, WebStorage.QuotaUpdater quotaUpdater) {
+        if (webChromeClientProxy != null) {
+            webChromeClientProxy.onExceededDatabaseQuota(url, databaseIdentifier, quota, estimatedDatabaseSize, totalQuota, quotaUpdater);
+        }
+        super.onExceededDatabaseQuota(url, databaseIdentifier, quota, estimatedDatabaseSize, totalQuota, quotaUpdater);
+    }
+
+    @Override
+    public void onReachedMaxAppCacheSize(long requiredStorage, long quota, WebStorage.QuotaUpdater quotaUpdater) {
+        if (webChromeClientProxy != null) {
+            webChromeClientProxy.onReachedMaxAppCacheSize(requiredStorage, quota, quotaUpdater);
+        }
+        super.onReachedMaxAppCacheSize(requiredStorage, quota, quotaUpdater);
+    }
+
+    @Override
+    public void onGeolocationPermissionsShowPrompt(String origin, GeolocationPermissions.Callback callback) {
+        if (webChromeClientProxy != null) {
+            webChromeClientProxy.onGeolocationPermissionsShowPrompt(origin, callback);
+        }
+        super.onGeolocationPermissionsShowPrompt(origin, callback);
+    }
+
+    @Override
+    public void onGeolocationPermissionsHidePrompt() {
+        if (webChromeClientProxy != null) {
+            webChromeClientProxy.onGeolocationPermissionsHidePrompt();
+        }
+        super.onGeolocationPermissionsHidePrompt();
+    }
+
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    @Override
+    public void onPermissionRequest(PermissionRequest request) {
+        if (webChromeClientProxy != null) {
+            webChromeClientProxy.onPermissionRequest(request);
+        }
+        super.onPermissionRequest(request);
+    }
+
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    @Override
+    public void onPermissionRequestCanceled(PermissionRequest request) {
+        if (webChromeClientProxy != null) {
+            webChromeClientProxy.onPermissionRequestCanceled(request);
+        }
+        super.onPermissionRequestCanceled(request);
+    }
+
+    @Override
+    public boolean onJsTimeout() {
+        if (webChromeClientProxy != null) {
+            webChromeClientProxy.onJsTimeout();
+        }
+        return super.onJsTimeout();
+    }
+
+    @Override
+    public void onConsoleMessage(String message, int lineNumber, String sourceID) {
+        if (webChromeClientProxy != null) {
+            webChromeClientProxy.onConsoleMessage(message, lineNumber, sourceID);
+        }
+        super.onConsoleMessage(message, lineNumber, sourceID);
+    }
+
+    @Override
+    public boolean onConsoleMessage(ConsoleMessage consoleMessage) {
+        if (webChromeClientProxy != null) {
+            webChromeClientProxy.onConsoleMessage(consoleMessage);
+        }
+        return super.onConsoleMessage(consoleMessage);
+    }
+
+    @Override
+    public Bitmap getDefaultVideoPoster() {
+        if (webChromeClientProxy != null) {
+            webChromeClientProxy.getDefaultVideoPoster();
+        }
+        return super.getDefaultVideoPoster();
+    }
+
+    @Override
+    public View getVideoLoadingProgressView() {
+        if (webChromeClientProxy != null) {
+            webChromeClientProxy.getVideoLoadingProgressView();
+        }
+        return super.getVideoLoadingProgressView();
+    }
+
+    @Override
+    public void getVisitedHistory(ValueCallback<String[]> callback) {
+        if (webChromeClientProxy != null) {
+            webChromeClientProxy.getVisitedHistory(callback);
+        }
+        super.getVisitedHistory(callback);
+    }
+
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    @Override
+    public boolean onShowFileChooser(WebView webView, ValueCallback<Uri[]> filePathCallback, FileChooserParams fileChooserParams) {
+        if (webChromeClientProxy != null) {
+            webChromeClientProxy.onShowFileChooser(webView, filePathCallback, fileChooserParams);
+        }
+        return super.onShowFileChooser(webView, filePathCallback, fileChooserParams);
+    }
+}

--- a/library/src/main/java/com/github/lzyzsd/jsbridge/BridgeWebView.java
+++ b/library/src/main/java/com/github/lzyzsd/jsbridge/BridgeWebView.java
@@ -7,7 +7,9 @@ import android.os.Looper;
 import android.os.SystemClock;
 import android.text.TextUtils;
 import android.util.AttributeSet;
+import android.webkit.WebChromeClient;
 import android.webkit.WebView;
+import android.webkit.WebViewClient;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -68,14 +70,20 @@ public class BridgeWebView extends WebView implements WebViewJavascriptBridge {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
             WebView.setWebContentsDebuggingEnabled(true);
         }
-		this.setWebViewClient(generateBridgeWebViewClient());
 	}
 
-    protected BridgeWebViewClient generateBridgeWebViewClient() {
-        return new BridgeWebViewClient(this);
-    }
 
-    /**
+	@Override
+	public void setWebViewClient(WebViewClient client) {
+		this.setWebViewClient(new BridgeWebViewClient(this, client));
+	}
+
+	@Override
+	public void setWebChromeClient(WebChromeClient client) {
+		super.setWebChromeClient(new BridgeWebChromeClient(client));
+	}
+
+	/**
      * 获取到CallBackFunction data执行调用并且从数据集移除
      * @param url
      */

--- a/library/src/main/java/com/github/lzyzsd/jsbridge/BridgeWebView.java
+++ b/library/src/main/java/com/github/lzyzsd/jsbridge/BridgeWebView.java
@@ -70,12 +70,14 @@ public class BridgeWebView extends WebView implements WebViewJavascriptBridge {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
             WebView.setWebContentsDebuggingEnabled(true);
         }
+        setWebViewClient(null);
+        setWebChromeClient(null);
 	}
 
 
 	@Override
 	public void setWebViewClient(WebViewClient client) {
-		this.setWebViewClient(new BridgeWebViewClient(this, client));
+		super.setWebViewClient(new BridgeWebViewClient(this, client));
 	}
 
 	@Override

--- a/library/src/main/java/com/github/lzyzsd/jsbridge/BridgeWebViewClient.java
+++ b/library/src/main/java/com/github/lzyzsd/jsbridge/BridgeWebViewClient.java
@@ -1,8 +1,16 @@
 package com.github.lzyzsd.jsbridge;
 
+import android.annotation.TargetApi;
 import android.graphics.Bitmap;
+import android.net.http.SslError;
 import android.os.Build;
+import android.view.KeyEvent;
+import android.webkit.ClientCertRequest;
+import android.webkit.HttpAuthHandler;
+import android.webkit.SslErrorHandler;
+import android.webkit.WebResourceError;
 import android.webkit.WebResourceRequest;
+import android.webkit.WebResourceResponse;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 
@@ -13,11 +21,13 @@ import java.net.URLDecoder;
  * 如果要自定义WebViewClient必须要集成此类
  * Created by bruce on 10/28/15.
  */
-public class BridgeWebViewClient extends WebViewClient {
+class BridgeWebViewClient extends WebViewClient {
     private BridgeWebView webView;
+    private WebViewClient webViewClientProxy;
 
-    public BridgeWebViewClient(BridgeWebView webView) {
+    public BridgeWebViewClient(BridgeWebView webView, WebViewClient webViewClient) {
         this.webView = webView;
+        this.webViewClientProxy = webViewClient;
     }
 
     @Override
@@ -35,47 +45,37 @@ public class BridgeWebViewClient extends WebViewClient {
             webView.flushMessageQueue();
             return true;
         } else {
+            if (webViewClientProxy != null) {
+                return webViewClientProxy.shouldOverrideUrlLoading(view, url);
+            }
             return super.shouldOverrideUrlLoading(view, url);
         }
     }
 
     // 增加shouldOverrideUrlLoading在api》=24时
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
     @Override
     public boolean shouldOverrideUrlLoading(WebView view, WebResourceRequest request) {
-
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            String url = request.getUrl().toString();
-            try {
-                url = URLDecoder.decode(url, "UTF-8");
-            } catch (UnsupportedEncodingException ex) {
-                ex.printStackTrace();
-            }
-            if (url.startsWith(BridgeUtil.YY_RETURN_DATA)) { // 如果是返回数据
-                webView.handlerReturnData(url);
-                return true;
-            } else if (url.startsWith(BridgeUtil.YY_OVERRIDE_SCHEMA)) { //
-                webView.flushMessageQueue();
-                return true;
-            } else {
-                return super.shouldOverrideUrlLoading(view, request);
-            }
-        }else {
-            return super.shouldOverrideUrlLoading(view, request);
-        }
+        return super.shouldOverrideUrlLoading(view, request.getUrl().toString());
     }
 
     @Override
     public void onPageStarted(WebView view, String url, Bitmap favicon) {
+        if (webViewClientProxy != null) {
+            webViewClientProxy.onPageStarted(view, url, favicon);
+        }
         super.onPageStarted(view, url, favicon);
     }
 
     @Override
     public void onPageFinished(WebView view, String url) {
+        if (webViewClientProxy != null) {
+            webViewClientProxy.onPageFinished(view, url);
+        }
         super.onPageFinished(view, url);
 
         BridgeUtil.webViewLoadLocalJs(view, BridgeWebView.toLoadJs);
 
-        //
         if (webView.getStartupMessage() != null) {
             for (Message m : webView.getStartupMessage()) {
                 webView.dispatchMessage(m);
@@ -83,4 +83,133 @@ public class BridgeWebViewClient extends WebViewClient {
             webView.setStartupMessage(null);
         }
     }
+
+    @Override
+    public void onLoadResource(WebView view, String url) {
+        if (webViewClientProxy != null) {
+            webViewClientProxy.onLoadResource(view, url);
+        }
+        super.onLoadResource(view, url);
+    }
+    @Override
+    public void onPageCommitVisible(WebView view, String url) {
+        if (webViewClientProxy != null) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                webViewClientProxy.onPageCommitVisible(view, url);
+            }
+        }
+        super.onPageCommitVisible(view, url);
+    }
+
+    @TargetApi(Build.VERSION_CODES.HONEYCOMB)
+    @Override
+    public WebResourceResponse shouldInterceptRequest(WebView view, String url) {
+        if (webViewClientProxy != null) {
+            webViewClientProxy.shouldInterceptRequest(view, url);
+        }
+        return super.shouldInterceptRequest(view, url);
+    }
+
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    @Override
+    public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
+        return shouldInterceptRequest(view, request.getUrl().toString());
+    }
+    @Override
+    public void onTooManyRedirects(WebView view, android.os.Message cancelMsg, android.os.Message continueMsg) {
+        if (webViewClientProxy != null) {
+            webViewClientProxy.onTooManyRedirects(view, cancelMsg, continueMsg);
+        }
+        super.onTooManyRedirects(view, cancelMsg, continueMsg);
+    }
+    @Override
+    public void onReceivedError(WebView view, int errorCode, String description, String failingUrl) {
+        if (webViewClientProxy != null) {
+            webViewClientProxy.onReceivedError(view, errorCode, description, failingUrl);
+        }
+        super.onReceivedError(view, errorCode, description, failingUrl);
+    }
+    @TargetApi(Build.VERSION_CODES.M)
+    @Override
+    public void onReceivedError(WebView view, WebResourceRequest request, WebResourceError error) {
+        if (webViewClientProxy != null) {
+            webViewClientProxy.onReceivedError(view, request, error);
+        }
+        super.onReceivedError(view, request, error);
+    }
+    @TargetApi(Build.VERSION_CODES.M)
+    @Override
+    public void onReceivedHttpError(WebView view, WebResourceRequest request, WebResourceResponse errorResponse) {
+        if (webViewClientProxy != null) {
+            webViewClientProxy.onReceivedHttpError(view, request, errorResponse);
+        }
+        super.onReceivedHttpError(view, request, errorResponse);
+    }
+    @Override
+    public void onFormResubmission(WebView view, android.os.Message dontResend, android.os.Message resend) {
+        if (webViewClientProxy != null) {
+            webViewClientProxy.onFormResubmission(view, dontResend, resend);
+        }
+        super.onFormResubmission(view, dontResend, resend);
+    }
+    @Override
+    public void doUpdateVisitedHistory(WebView view, String url, boolean isReload) {
+        if (webViewClientProxy != null) {
+            webViewClientProxy.doUpdateVisitedHistory(view, url, isReload);
+        }
+        super.doUpdateVisitedHistory(view, url, isReload);
+    }
+    @Override
+    public void onReceivedSslError(WebView view, SslErrorHandler handler, SslError error) {
+        if (webViewClientProxy != null) {
+            webViewClientProxy.onReceivedSslError(view, handler, error);
+        }
+        super.onReceivedSslError(view, handler, error);
+    }
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    @Override
+    public void onReceivedClientCertRequest(WebView view, ClientCertRequest request) {
+        if (webViewClientProxy != null) {
+            webViewClientProxy.onReceivedClientCertRequest(view, request);
+        }
+        super.onReceivedClientCertRequest(view, request);
+    }
+    @Override
+    public void onReceivedHttpAuthRequest(WebView view, HttpAuthHandler handler, String host, String realm) {
+        if (webViewClientProxy != null) {
+            webViewClientProxy.onReceivedHttpAuthRequest(view, handler, host, realm);
+        }
+        super.onReceivedHttpAuthRequest(view, handler, host, realm);
+    }
+    @Override
+    public boolean shouldOverrideKeyEvent(WebView view, KeyEvent event) {
+        if (webViewClientProxy != null) {
+            webViewClientProxy.shouldOverrideKeyEvent(view, event);
+        }
+        return super.shouldOverrideKeyEvent(view, event);
+    }
+    @Override
+    public void onUnhandledKeyEvent(WebView view, KeyEvent event) {
+        if (webViewClientProxy != null) {
+            webViewClientProxy.onUnhandledKeyEvent(view, event);
+        }
+        super.onUnhandledKeyEvent(view, event);
+    }
+    @Override
+    public void onScaleChanged(WebView view, float oldScale, float newScale) {
+        if (webViewClientProxy != null) {
+            webViewClientProxy.onScaleChanged(view, oldScale, newScale);
+        }
+        super.onScaleChanged(view, oldScale, newScale);
+    }
+    @TargetApi(Build.VERSION_CODES.HONEYCOMB_MR1)
+    @Override
+    public void onReceivedLoginRequest(WebView view, String realm, String account, String args) {
+        if (webViewClientProxy != null) {
+            webViewClientProxy.onReceivedLoginRequest(view,realm, account, args);
+        }
+        super.onReceivedLoginRequest(view, realm, account, args);
+    }
+
+
 }

--- a/library/src/main/java/com/github/lzyzsd/jsbridge/BridgeWebViewClient.java
+++ b/library/src/main/java/com/github/lzyzsd/jsbridge/BridgeWebViewClient.java
@@ -73,9 +73,7 @@ public class BridgeWebViewClient extends WebViewClient {
     public void onPageFinished(WebView view, String url) {
         super.onPageFinished(view, url);
 
-        if (BridgeWebView.toLoadJs != null) {
-            BridgeUtil.webViewLoadLocalJs(view, BridgeWebView.toLoadJs);
-        }
+        BridgeUtil.webViewLoadLocalJs(view, BridgeWebView.toLoadJs);
 
         //
         if (webView.getStartupMessage() != null) {

--- a/library/src/main/java/com/github/lzyzsd/jsbridge/CallBackFunction.java
+++ b/library/src/main/java/com/github/lzyzsd/jsbridge/CallBackFunction.java
@@ -2,6 +2,6 @@ package com.github.lzyzsd.jsbridge;
 
 public interface CallBackFunction {
 	
-	public void onCallBack(String data);
+	void onCallBack(String data);
 
 }

--- a/library/src/main/java/com/github/lzyzsd/jsbridge/WebViewJavascriptBridge.java
+++ b/library/src/main/java/com/github/lzyzsd/jsbridge/WebViewJavascriptBridge.java
@@ -3,9 +3,6 @@ package com.github.lzyzsd.jsbridge;
 
 public interface WebViewJavascriptBridge {
 	
-	public void send(String data);
-	public void send(String data, CallBackFunction responseCallback);
-	
-	
-
+	void send(String data);
+	void send(String data, CallBackFunction responseCallback);
 }


### PR DESCRIPTION
重写ProgressWebView的setWebviewClient()和setWebChromeClient方法，内部默认设置BridgeWebViewClient，外部业务方使用的时候可以正常设置自己的webivewclient。并且可以对外屏蔽BridgeWebViewClient的细节