### PR TITLE
修复json消息中有特殊字符，js消息丢失的情况

### DIFF
--- a/library/src/main/assets/WebViewJavascriptBridge.js
+++ b/library/src/main/assets/WebViewJavascriptBridge.js
@@ -79,7 +79,9 @@
         var messageQueueString = JSON.stringify(sendMessageQueue);
         sendMessageQueue = [];
         //android can't read directly the return data, so we can reload iframe src to communicate with java
-        bizMessagingIframe.src = CUSTOM_PROTOCOL_SCHEME + '://return/_fetchQueue/' + encodeURIComponent(messageQueueString);
+        if (messageQueueString !== '[]') {
+            bizMessagingIframe.src = CUSTOM_PROTOCOL_SCHEME + '://return/_fetchQueue/' + encodeURIComponent(messageQueueString);
+        }
     }
 
     //提供给native使用,

--- a/library/src/main/java/com/github/lzyzsd/jsbridge/BridgeWebView.java
+++ b/library/src/main/java/com/github/lzyzsd/jsbridge/BridgeWebView.java
@@ -8,6 +8,7 @@ import android.os.SystemClock;
 import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.webkit.WebView;
+import java.net.URLEncoder;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -144,6 +145,9 @@ public class BridgeWebView extends WebView implements WebViewJavascriptBridge {
         messageJson = messageJson.replaceAll("(\\\\)([^utrn])", "\\\\\\\\$1$2");
         messageJson = messageJson.replaceAll("(?<=[^\\\\])(\")", "\\\\\"");
 		messageJson = messageJson.replaceAll("(?<=[^\\\\])(\')", "\\\\\'");
+		messageJson = messageJson.replaceAll("%7B", URLEncoder.encode("%7B"));
+		messageJson = messageJson.replaceAll("%7D", URLEncoder.encode("%7D"));
+		messageJson = messageJson.replaceAll("%22", URLEncoder.encode("%22"));
         String javascriptCommand = String.format(BridgeUtil.JS_HANDLE_MESSAGE_FROM_JAVA, messageJson);
         // 必须要找主线程才会将数据传递出去 --- 划重点
         if (Thread.currentThread() == Looper.getMainLooper().getThread()) {
@@ -238,10 +242,10 @@ public class BridgeWebView extends WebView implements WebViewJavascriptBridge {
 			messageHandlers.put(handlerName, handler);
 		}
 	}
-	
+
 	/**
 	 * unregister handler
-	 * 
+	 *
 	 * @param handlerName
 	 */
 	public void unregisterHandler(String handlerName) {


### PR DESCRIPTION
`%7B, %7D, %22` 对应 {}",在js中直接decode了字符，应该先encode

并发时，` _fetchQueue()`重复调用时会产生空消息[], 导致之前的callback无法返回