### PR TITLE
处理 BridgeHelper.shouldOverrideUrlLoading(String url) 方法 URLDecoder.decode 可能的崩溃

### DIFF
--- a/library/src/main/java/com/github/lzyzsd/jsbridge/BridgeHelper.java
+++ b/library/src/main/java/com/github/lzyzsd/jsbridge/BridgeHelper.java
@@ -269,7 +269,9 @@ public class BridgeHelper implements WebViewJavascriptBridge {
 
     public boolean shouldOverrideUrlLoading(String url) {
         try {
-            url = URLDecoder.decode(url, "UTF-8");
+            // decode 之前，处理 % 和 +
+            String replacedUrl = url.replaceAll("%(?![0-9a-fA-F]{2})", "%25").replaceAll("\\+", "%2B");
+            url = URLDecoder.decode(replacedUrl, "UTF-8");
         } catch (UnsupportedEncodingException e) {
             Log.w(TAG, e);
         }


### PR DESCRIPTION
BridgeHelper.shouldOverrideUrlLoading(String url) 方法，如果传人的 url 中包含未编码的符号“%”和“+”，会导致 URLDecoder.decode 抛出 IllegalArgumentException，所以在 decode 前使用正则将该特殊符号进行编码处理。

或者大家看看是否有其他更好的方案。